### PR TITLE
Fixes to migrate-uploads-data

### DIFF
--- a/greenhouse/uploads/management/commands/migrate-upload-data.py
+++ b/greenhouse/uploads/management/commands/migrate-upload-data.py
@@ -10,17 +10,16 @@ class Command(NoArgsCommand):
     help = "Migrate upload data from UDD to django managed database."
 
     def import_uploads(self):
-        greatest = []
         CHUNK_SIZE = 5000
         try:
-            now = UDD.objects.order_by('-date').filter(
+            now = UDD.objects.order_by('date').filter(
                 date__lte=timezone.now()).reverse()[0].date
             current = latest = Uploads.objects.latest('timestamp').timestamp
         except ObjectDoesNotExist:
-            current = latest = UDD.objects.order_by('date').date
+            current = latest = UDD.objects.order_by('date')[0].date
         while current < now:
             for u in UDD.objects.order_by(
-                    '-date').filter(date__gt=current)[:CHUNK_SIZE]:
+                    'date').filter(date__gt=current)[:CHUNK_SIZE]:
                 if u.date < now:
                     uploads = Uploads(timestamp=u.date,
                                       release=u.distribution,


### PR DESCRIPTION
-removed 'greatest = []', it was being used for testing and should've been removed
-several places should have been using "order_by('date')" not "order_by('-date')"
-should have been trying to select the first object on the exception
-it's taking even less memory than before now, 48MB, have no idea why
-decided to keep "gc.collect()", it makes no difference with chunk_size=5000 but with chunk_size=10000 the memory use climbs, not sure
why that happens only happens with a larger chunk_size
